### PR TITLE
simplify engine printing

### DIFF
--- a/R/persistence-class.R
+++ b/R/persistence-class.R
@@ -210,7 +210,7 @@ format.persistence <- function(x, ...) {
 
     cli::cli_h1("Metadata")
     filt_nm <- capitalize(x$metadata$filtration)
-    cli::cli_alert_info("Computed from a {filt_nm} filtration using the {.fn {x$metadata$engine}} engine")
+    cli::cli_alert_info("Computed from a {filt_nm} filtration using {.fn {x$metadata$engine}}")
     if (!is.null(param_nms))
       cli::cli_alert_info("with the following parameters: {param_nms}.")
   })

--- a/R/persistence-class.R
+++ b/R/persistence-class.R
@@ -210,16 +210,18 @@ format.persistence <- function(x, ...) {
     if (filt_nm == "?" && x$metadata$engine == "?") {
       cli::cli_alert_warning("Both filtration and computation engine are unknown.")
     } else if (filt_nm == "?") {
+      cli::cli_alert_info("Computed using {.fn {x$metadata$engine}}.")
       cli::cli_alert_warning("Filtration is unknown.")
     } else if (x$metadata$engine == "?") {
+      cli::cli_alert_info("Computed from a {filt_nm} filtration.")
       cli::cli_alert_warning("Computation engine is unknown.")
     } else {
-      cli::cli_alert_info("Computed from a {filt_nm} filtration using {.fn {x$metadata$engine}}")
-      if (is.null(param_nms)) {
-        cli::cli_alert_warning("with unknown parameters.")
-      } else {
-        cli::cli_alert_info("with the following parameters: {param_nms}.")
-      }
+      cli::cli_alert_info("Computed from a {filt_nm} filtration using {.fn {x$metadata$engine}}.")
+    }
+    if (is.null(param_nms)) {
+      cli::cli_alert_warning("With unknown parameters.")
+    } else {
+      cli::cli_alert_info("With the following parameters: {param_nms}.")
     }
   })
 }

--- a/R/persistence-class.R
+++ b/R/persistence-class.R
@@ -202,17 +202,25 @@ format.persistence <- function(x, ...) {
     param_nms <- names(param_vals)
     param_nms <- paste(param_nms, "=", param_vals)
   }
+  filt_nm <- capitalize(x$metadata$filtration)
 
   cli::cli_format_method({
-    cli::cli_h3("Persistence Data")
-
+    cli::cli_h1("Persistence Data")
     cli::cli_alert_info('There are {npts} {cli::qty(max_npts)}pair{?s} in {cli::qty(ndim)}dimension{?s} {seq_len(ndim) - 1L} respectively.')
-
-    cli::cli_h3("Metadata")
-    filt_nm <- capitalize(x$metadata$filtration)
-    cli::cli_alert_info("Computed from a {filt_nm} filtration using {.fn {x$metadata$engine}}")
-    if (!is.null(param_nms))
-      cli::cli_alert_info("with the following parameters: {param_nms}.")
+    if (filt_nm == "?" && x$metadata$engine == "?") {
+      cli::cli_alert_warning("Both filtration and computation engine are unknown.")
+    } else if (filt_nm == "?") {
+      cli::cli_alert_warning("Filtration is unknown.")
+    } else if (x$metadata$engine == "?") {
+      cli::cli_alert_warning("Computation engine is unknown.")
+    } else {
+      cli::cli_alert_info("Computed from a {filt_nm} filtration using {.fn {x$metadata$engine}}")
+      if (is.null(param_nms)) {
+        cli::cli_alert_warning("with unknown parameters.")
+      } else {
+        cli::cli_alert_info("with the following parameters: {param_nms}.")
+      }
+    }
   })
 }
 

--- a/R/persistence-class.R
+++ b/R/persistence-class.R
@@ -204,11 +204,11 @@ format.persistence <- function(x, ...) {
   }
 
   cli::cli_format_method({
-    cli::cli_h1("Persistence Data")
+    cli::cli_h3("Persistence Data")
 
     cli::cli_alert_info('There are {npts} {cli::qty(max_npts)}pair{?s} in {cli::qty(ndim)}dimension{?s} {seq_len(ndim)} respectively.')
 
-    cli::cli_h1("Metadata")
+    cli::cli_h3("Metadata")
     filt_nm <- capitalize(x$metadata$filtration)
     cli::cli_alert_info("Computed from a {filt_nm} filtration using {.fn {x$metadata$engine}}")
     if (!is.null(param_nms))

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ as_persistence(noisy_circle_ripserr)
 #> 
 #> ── Persistence Data ────────────────────────────────────────────────────────────
 #> ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
-#> ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`
-#> ! with unknown parameters.
+#> ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`.
+#> ! With unknown parameters.
 ```
 
 Similarly, the persistence data computed using the **TDA** package can
@@ -132,6 +132,6 @@ as_persistence(noisy_circle_tda_rips)
 #> 
 #> ── Persistence Data ────────────────────────────────────────────────────────────
 #> ℹ There are 100 and 2 pairs in dimensions 0 and 1 respectively.
-#> ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`
-#> ℹ with the following parameters: maxdimension = 1 and maxscale = 1.6322.
+#> ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`.
+#> ℹ With the following parameters: maxdimension = 1 and maxscale = 1.6322.
 ```

--- a/README.md
+++ b/README.md
@@ -119,10 +119,9 @@ into the ‘persistence’ class as follows:
 as_persistence(noisy_circle_ripserr)
 #> 
 #> ── Persistence Data ────────────────────────────────────────────────────────────
-#> ℹ There are 99 and 2 pairs in dimensions 1 and 2 respectively.
-#> 
-#> ── Metadata ────────────────────────────────────────────────────────────────────
-#> ℹ Computed from a Vietoris-Rips filtration using the `ripserr::vietoris_rips()` engine
+#> ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
+#> ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`
+#> ! with unknown parameters.
 ```
 
 Similarly, the persistence data computed using the **TDA** package can
@@ -132,9 +131,7 @@ be converted into the ‘persistence’ class as follows:
 as_persistence(noisy_circle_tda_rips)
 #> 
 #> ── Persistence Data ────────────────────────────────────────────────────────────
-#> ℹ There are 100 and 2 pairs in dimensions 1 and 2 respectively.
-#> 
-#> ── Metadata ────────────────────────────────────────────────────────────────────
-#> ℹ Computed from a Vietoris-Rips filtration using the `TDA::ripsDiag()` engine
+#> ℹ There are 100 and 2 pairs in dimensions 0 and 1 respectively.
+#> ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`
 #> ℹ with the following parameters: maxdimension = 1 and maxscale = 1.6322.
 ```

--- a/inst/tinytest/_tinysnapshot/print-mat-persistence-engine.txt
+++ b/inst/tinytest/_tinysnapshot/print-mat-persistence-engine.txt
@@ -1,5 +1,6 @@
 
 ── Persistence Data ────────────────────────────────────────────────────────────
-ℹ There are 100 and 2 pairs in dimensions 0 and 1 respectively.
-ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`.
+ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
+ℹ Computed using `ripserr::vietoris_rips()`.
+! Filtration is unknown.
 ℹ With the following parameters: maxdimension = 1 and maxscale = 1.6322.

--- a/inst/tinytest/_tinysnapshot/print-mat-persistence-filtration.txt
+++ b/inst/tinytest/_tinysnapshot/print-mat-persistence-filtration.txt
@@ -1,5 +1,6 @@
 
 ── Persistence Data ────────────────────────────────────────────────────────────
 ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
-ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`.
+ℹ Computed from a Vietoris-Rips filtration.
+! Computation engine is unknown.
 ! With unknown parameters.

--- a/inst/tinytest/_tinysnapshot/print-mat-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-mat-persistence.txt
@@ -2,3 +2,4 @@
 ── Persistence Data ────────────────────────────────────────────────────────────
 ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
 ! Both filtration and computation engine are unknown.
+! With unknown parameters.

--- a/inst/tinytest/_tinysnapshot/print-mat-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-mat-persistence.txt
@@ -3,5 +3,5 @@
 ℹ There are 99 and 2 pairs in dimensions 1 and 2 respectively.
 
 ── Metadata ────────────────────────────────────────────────────────────────────
-ℹ Computed from a ? filtration using the `?()` engine
+ℹ Computed from a ? filtration using `?()`
 ℹ with the following parameters: maxdimension = 1 and maxscale = 1.6322.

--- a/inst/tinytest/_tinysnapshot/print-mat-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-mat-persistence.txt
@@ -1,7 +1,4 @@
 
 ── Persistence Data ────────────────────────────────────────────────────────────
-ℹ There are 99 and 2 pairs in dimensions 1 and 2 respectively.
-
-── Metadata ────────────────────────────────────────────────────────────────────
-ℹ Computed from a ? filtration using `?()`
-ℹ with the following parameters: maxdimension = 1 and maxscale = 1.6322.
+ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
+! Both filtration and computation engine are unknown.

--- a/inst/tinytest/_tinysnapshot/print-ripserr-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-ripserr-persistence.txt
@@ -3,4 +3,4 @@
 ℹ There are 99 and 2 pairs in dimensions 1 and 2 respectively.
 
 ── Metadata ────────────────────────────────────────────────────────────────────
-ℹ Computed from a Vietoris-Rips filtration using the `ripserr::vietoris_rips()` engine
+ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`

--- a/inst/tinytest/_tinysnapshot/print-ripserr-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-ripserr-persistence.txt
@@ -1,6 +1,5 @@
 
 ── Persistence Data ────────────────────────────────────────────────────────────
-ℹ There are 99 and 2 pairs in dimensions 1 and 2 respectively.
-
-── Metadata ────────────────────────────────────────────────────────────────────
+ℹ There are 99 and 2 pairs in dimensions 0 and 1 respectively.
 ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`
+! with unknown parameters.

--- a/inst/tinytest/_tinysnapshot/print-tda-rips-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-tda-rips-persistence.txt
@@ -3,5 +3,5 @@
 ℹ There are 100 and 2 pairs in dimensions 1 and 2 respectively.
 
 ── Metadata ────────────────────────────────────────────────────────────────────
-ℹ Computed from a Vietoris-Rips filtration using the `TDA::ripsDiag()` engine
+ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`
 ℹ with the following parameters: maxdimension = 1 and maxscale = 1.6322.

--- a/inst/tinytest/_tinysnapshot/print-tda-rips-persistence.txt
+++ b/inst/tinytest/_tinysnapshot/print-tda-rips-persistence.txt
@@ -1,7 +1,5 @@
 
 ── Persistence Data ────────────────────────────────────────────────────────────
-ℹ There are 100 and 2 pairs in dimensions 1 and 2 respectively.
-
-── Metadata ────────────────────────────────────────────────────────────────────
+ℹ There are 100 and 2 pairs in dimensions 0 and 1 respectively.
 ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`
 ℹ with the following parameters: maxdimension = 1 and maxscale = 1.6322.

--- a/inst/tinytest/test-persistence-class.R
+++ b/inst/tinytest/test-persistence-class.R
@@ -12,11 +12,17 @@ expect_equal(mat$metadata$engine, "?")
 expect_equal(mat$metadata$filtration, "?")
 expect_equal(mat$metadata$call, "?")
 expect_equal(mat$metadata$parameters, list())
+expect_snapshot_print(mat, label = "print-mat-persistence")
 
 params <- list(maxdimension = 1L, maxscale = 1.6322)
-mat <- as_persistence(M, parameters = params)
+mat <- as_persistence(M, engine = "ripserr::vietoris_rips", parameters = params)
+expect_equal(mat$metadata$engine, "ripserr::vietoris_rips")
 expect_equal(mat$metadata$parameters, params)
-expect_snapshot_print(mat, label = "print-mat-persistence")
+expect_snapshot_print(mat, label = "print-mat-persistence-engine")
+
+mat <- as_persistence(M, filtration = "vietoris-rips")
+expect_equal(mat$metadata$filtration, "vietoris-rips")
+expect_snapshot_print(mat, label = "print-mat-persistence-filtration")
 
 wrong_df <- noisy_circle_ripserr
 wrong_df$morevar <- 1L


### PR DESCRIPTION
This just struck me as a helpful simplification of the printout. Feel free to reject, but it seemed better to illustrate it with a PR than to talk through it!

``` r
tdaunif::sample_circle(n = 24) |> 
  TDA::ripsDiag(maxdimension = 2L, maxscale = 4) |> 
  getElement("diagram") |> 
  as_persistence()
#> 
#> ── Persistence Data ────────────────────────────────────────────────────────────
#> ℹ There are 24, 1, and 2 pairs in dimensions 1, 2, and 3 respectively.
#> 
#> ── Metadata ────────────────────────────────────────────────────────────────────
#> ℹ Computed from a Vietoris-Rips filtration using `TDA::ripsDiag()`
#> ℹ with the following parameters: maxdimension = 2 and maxscale = 4.

tdaunif::sample_circle(n = 24) |> 
  TDA::alphaComplexDiag(maxdimension = 2L) |> 
  getElement("diagram") |> 
  as_persistence()
#> 
#> ── Persistence Data ────────────────────────────────────────────────────────────
#> ℹ There are 24 and 8 pairs in dimensions 1 and 2 respectively.
#> 
#> ── Metadata ────────────────────────────────────────────────────────────────────
#> ℹ Computed from a Alphacomplex filtration using `TDA::alphaComplexDiag()`
#> ℹ with the following parameters: maxdimension = 2.

tdaunif::sample_circle(n = 24) |> 
  ripserr::vietoris_rips() |> 
  as_persistence()
#> 
#> ── Persistence Data ────────────────────────────────────────────────────────────
#> ℹ There are 23 and 1 pairs in dimensions 1 and 2 respectively.
#> 
#> ── Metadata ────────────────────────────────────────────────────────────────────
#> ℹ Computed from a Vietoris-Rips filtration using `ripserr::vietoris_rips()`
```

<sup>Created on 2025-04-05 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>