### PR TITLE
Supported formats

### DIFF
--- a/R/persistence-class.R
+++ b/R/persistence-class.R
@@ -19,14 +19,24 @@
 #' @param x An `R` object containing the persistence data to be coerced into an
 #'   object of class [`persistence`]. Currently supported forms are:
 #'
-#' - a \eqn{\geq 3}-column matrix (or object coercible to one) with
-#' dimension/degree, start/birth and end/death columns,
-#' - a list whose first element is such an object,
+#' - a \eqn{\geq 2}-column matrix (or object coercible to one) with
+#' dimension/degree, start/birth and end/death columns; if it has only 2
+#' columns, we assume that the `dimension` column is missing and we set it to
+#' `0` (i.e. we assume that the data is in the form `birth` and `death`),
+#' - a [`base::data.frame`] (or object coercible to one) with at least 3 columns
+#' containing the persistence data; if it has only 2 columns, we assume that the
+#' `dimension` column is missing and we set it to `0`,
+#' - a list of 2-column matrices (or objects coercible to one) with the first column
+#' being the birth and the second column being the death of homological
+#' features; indexed by dimension, i.e. the \eqn{i}-*th* element of the list
+#' corresponds to the \eqn{(i-1)}-*th* homology dimension,
 #' - an object of class 'PHom' as returned by
 #' [`ripserr::vietoris_rips()`](https://tdaverse.github.io/ripserr/reference/vietoris_rips.html),
 #' - (a list as returned by a `*Diag()` function in __TDA__ (e.g.
 #' [`TDA::ripsDiag()`](https://www.rdocumentation.org/packages/TDA/versions/1.9.1/topics/ripsDiag))
-#' whose first element is) an object of class 'diagram'.
+#' whose first element is) an object of class 'diagram',
+#' - an object of class [`stats::hclust`] in which case we use the entry `height`
+#' as the death of homological features and 0 as the birth of all features.
 #'
 #' @param warn A boolean specifying whether to issue a warning if the input
 #'   persistence data contained unordered pairs. Defaults to `TRUE`.
@@ -229,19 +239,15 @@ as_persistence.matrix <- function(x, warn = TRUE, ...) {
     } else {
       x <- cbind(0L, x)
     }
-    colnames(x) <- c("dimension", "birth", "death")
     n_columns <- 3L
   }
 
-  column_names <- colnames(x)
-  if (is.null(column_names)) {
-    colnames(x) <- c(
-      "dimension",
-      "birth",
-      "death",
-      if (n_columns > 3L) paste0("extra_", seq_len(n_columns - 3L))
-    )
-  }
+  colnames(x) <- c(
+    "dimension",
+    "birth",
+    "death",
+    if (n_columns > 3L) paste0("extra_", seq_len(n_columns - 3L))
+  )
 
   x <- as.data.frame(x)
   as_persistence.data.frame(x, warn = warn, ...)

--- a/man/persistence.Rd
+++ b/man/persistence.Rd
@@ -47,14 +47,24 @@ get_pairs(x, dimension, ...)
 \item{x}{An \code{R} object containing the persistence data to be coerced into an
 object of class \code{\link{persistence}}. Currently supported forms are:
 \itemize{
-\item a \eqn{\geq 3}-column matrix (or object coercible to one) with
-dimension/degree, start/birth and end/death columns,
-\item a list whose first element is such an object,
+\item a \eqn{\geq 2}-column matrix (or object coercible to one) with
+dimension/degree, start/birth and end/death columns; if it has only 2
+columns, we assume that the \code{dimension} column is missing and we set it to
+\code{0} (i.e. we assume that the data is in the form \code{birth} and \code{death}),
+\item a \code{\link[base:data.frame]{base::data.frame}} (or object coercible to one) with at least 3 columns
+containing the persistence data; if it has only 2 columns, we assume that the
+\code{dimension} column is missing and we set it to \code{0},
+\item a list of 2-column matrices (or objects coercible to one) with the first column
+being the birth and the second column being the death of homological
+features; indexed by dimension, i.e. the \eqn{i}-\emph{th} element of the list
+corresponds to the \eqn{(i-1)}-\emph{th} homology dimension,
 \item an object of class 'PHom' as returned by
 \href{https://tdaverse.github.io/ripserr/reference/vietoris_rips.html}{\code{ripserr::vietoris_rips()}},
 \item (a list as returned by a \verb{*Diag()} function in \strong{TDA} (e.g.
 \href{https://www.rdocumentation.org/packages/TDA/versions/1.9.1/topics/ripsDiag}{\code{TDA::ripsDiag()}})
-whose first element is) an object of class 'diagram'.
+whose first element is) an object of class 'diagram',
+\item an object of class \code{\link[stats:hclust]{stats::hclust}} in which case we use the entry \code{height}
+as the death of homological features and 0 as the birth of all features.
 }}
 
 \item{warn}{A boolean specifying whether to issue a warning if the input

--- a/man/phutil-package.Rd
+++ b/man/phutil-package.Rd
@@ -20,9 +20,9 @@ Useful links:
 \author{
 \strong{Maintainer}: Aymeric Stamm \email{aymeric.stamm@cnrs.fr} (\href{https://orcid.org/0000-0002-8725-3654}{ORCID})
 
-Other contributors:
+Authors:
 \itemize{
-  \item Jason Cory Brunson \email{cornelioid@gmail.com} (\href{https://orcid.org/0000-0003-3126-9494}{ORCID}) [contributor]
+  \item Jason Cory Brunson \email{cornelioid@gmail.com} (\href{https://orcid.org/0000-0003-3126-9494}{ORCID})
 }
 
 }

--- a/vignettes/persistence-class.qmd
+++ b/vignettes/persistence-class.qmd
@@ -1,0 +1,112 @@
+---
+title: "The persistence class"
+vignette: >
+  %\VignetteIndexEntry{The persistence class}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+knitr:
+  opts_chunk:
+    collapse: true
+    comment: '#>'
+---
+
+```{r}
+#| label: setup
+library(phutil)
+```
+
+## Structure of the class
+
+An object of class `persistence` is a list of 2 elements:
+
+- `pairs`: A list of 2-column matrices containing birth-death pairs. The
+$i$-*th* element of the list corresponds to the $(i-1)$-*th* homology
+dimension. If there is no pairs for a given dimension but there are pairs in
+higher dimensions, the corresponding element(s) is/are filled with a
+\eqn{0 \times 2} numeric matrix with 0 rows.
+
+- `metadata`: A list of length 6 containing information about how the data
+was computed:
+
+    - `orderered_pairs`: A boolean indicating whether the pairs in the
+    `pairs` list are ordered (i.e. the first column is strictly less than the
+    second column).
+    - `data`: The name of the object containing the original data on which the
+    persistence data was computed.
+    - `engine`: The name of the package and the function of this package that
+    computed the persistence data in the form
+    `"package_name::package_function"`.
+    - `filtration`: The filtration used in the computation in a human-readable
+    format (i.e. full names, capitals where needed, etc.).
+    - `parameters`: A list of parameters used in the computation.
+    - `call`: The exact call that generated the persistence data.
+
+## Supported inputs
+
+The `persistence` class is designed to support a variety of inputs, including
+
+A single numeric matrix
+
+: If the user provides a matrix, it must have at least 2 columns and each row
+represents a topological feature.
+
+- If it has 2 columns, we assume that the first column corresponds to the birth
+of a feature and the second column corresponds to the death of a feature,
+irrespective of the order of the columns. In this case, we assume that the
+homology dimension of the feature is 0.
+
+- If it has more than 2 columns, we assume that the first column corresponds to
+the homology dimension of the feature, the second column corresponds to the
+birth of a feature, and the third column corresponds to the death of a feature,
+irrespective of the order of the columns. The remaining columns are ignored.
+
+A list of numeric matrices
+
+: If the user provides a list of matrices, each list element corresponds to an
+homology dimension, from 0 to some maximum value. Each matrix must have at least
+2 columns and each row represents a topological feature in the corresponding
+homology dimension (given by the matrix index in the list minus 1). Each matrix
+is parsed as described above.
+
+A dataframe
+
+: If the user provides an object of class `data.frame`, it must have at least 2
+columns and each row represents a topological feature. If it has exactly 2
+columns, we add a `dimension` column with all values set to 0. If it has more
+than 2 columns, we require that `birth` and `death` exist in the column names.
+The `birth` and `death` columns are parsed as described above. The remaining
+columns are ignored.
+
+An object of class 'PHom'
+
+: If the user provides an object of class 'PHom' as typically produced by
+`ripserr::vietoris_rips()`, it means that it is a `base::data.frame` with
+columns `dimension`, `birth`, and `death` in that specific order. The
+`dimension` column is of type integer while the `birth` and `death` columns are
+of type numeric. The `dimension` column is used to create a list of matrices,
+where each matrix corresponds to an homology dimension, from 0 to the maximum
+value in the `dimension` column.
+
+An object of class 'diagram'
+
+: If the user provides an object of class 'diagram' as typically produced by
+`TDA::*Diag()` functions in entry `diagram`, it means that it is a
+`base::matrix` with 3 columns with names `dimension`, `Birth` and `Death` in
+that specific order. The `dimension` column is of type integer while the `Birth`
+and `Death` columns are of type numeric. Furthermore, the object stores as
+attributes the parameters used to compute the diagram and the entire call to the
+function that produced the diagram. We first lowercase `Birth` and `Death`.
+Next, the `dimension` column is used to create a list of matrices, where each
+matrix corresponds to an homology dimension, from 0 to the maximum value in the
+`dimension` column. The `birth` and `death` columns are parsed as described
+above. The remaining columns are ignored.
+
+An object of class 'hclust'
+
+: If the user provides an object of class 'hclust' as typically produced by
+`stats::hclust()`, it means that it is a `base::list` which contains the
+`height` element which is a set of $n−1$ real values (non-decreasing for
+ultrametric trees) storing the clustering height, that is, the value of the
+criterion associated with the clustering method for the particular
+agglomeration. This is used as homological feature death while a birth of `0` is
+typically used.


### PR DESCRIPTION
- Adds a vignette about the persistence class, explaining its structure and the supported input formats and how they are currently parsed;
- Change matrix parser; specifically, if 2 columns, we assume these are birth and death in that order and left-append a dimension column full of 0s; if 3 or more columns, we assume the first three are dimension, birth and death in that order.

