### PR TITLE
replace length-0 with empty character when do.call of TDA::*Diag is passed to as_persistence.diagram - fixes #54

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # phutil (development version)
 
+## Bug fixes
+
+- `as_persistence.diagram()` would fail when the input was obtained through `do.call()`; it now continues without error, but with empty information about the engine.
+
 # phutil 0.0.2
 
 ## New features

--- a/R/persistence-class.R
+++ b/R/persistence-class.R
@@ -274,6 +274,8 @@ as_persistence.diagram <- function(x, warn = TRUE, ...) {
   bd_cols <- match(c("Birth", "Death"), info$dimnames[[2L]])
 
   filt_nm <- gsub("*Diag", "", rlang::call_name(info$call))
+  # when using `do.call()`, call does not include `TDA::*Diag()`
+  if (length(filt_nm) == 0L) filt_nm <- ""
   if (filt_nm == "rips") {
     filt_nm <- "Vietoris-Rips"
   }

--- a/inst/tinytest/test-persistence-class.R
+++ b/inst/tinytest/test-persistence-class.R
@@ -191,4 +191,8 @@ if (requireNamespace("ripserr", quietly = TRUE)) {
   expect_true(!is.list(as_diagram(h, list = FALSE)))
 }
 
+# tolerate `do.call()` input
+ph <- do.call(ripsDiag, c(list(X = x, maxdimension = 2, maxscale = 10)))
+expect_silent(as_persistence(ph))
+
 options(opts)


### PR DESCRIPTION
`as_persistence.diagram()` would fail when the input was obtained through `do.call()`; it now continues without error, but with empty information about the engine.

This problem should be more carefully handled in future; this is just a stopgap.